### PR TITLE
Add python-3.12 devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,11 +3,9 @@ LABEL org.opencontainers.image.authors="https://github.com/nqngo"
 LABEL description="Python 3.12 devcontainer with poetry"
 
 # Configure the dev environment
-RUN apt update && \
-    apt install -y bash-completion && \
+RUN apt-get update && \
+    apt-get install -y bash-completion && \
     rm -rf /var/lib/apt/list/*
 # Configure poetry
-USER vscode
-WORKDIR /home/vscode
-RUN curl -sSL https://install.python-poetry.org | python3 - && \
-    .local/bin/poetry completions bash | sudo tee -a /etc/bash_completion.d/poetry
+RUN pipx install poetry && \
+    poetry completions bash > /etc/bash_completion.d/poetry

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/python:3.12
+LABEL org.opencontainers.image.authors="https://github.com/nqngo"
+LABEL description="Python 3.12 devcontainer with poetry"
+
+# Configure the dev environment
+RUN apt update && \
+    apt install -y bash-completion && \
+    rm -rf /var/lib/apt/list/*
+# Configure poetry
+USER vscode
+WORKDIR /home/vscode
+RUN curl -sSL https://install.python-poetry.org | python3 - && \
+    .local/bin/poetry completions bash | sudo tee -a /etc/bash_completion.d/poetry

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Python 3.12",
-  "image": "ghcr.io/bifrostlab/llm-assistant:latest",
+  "image": "ghcr.io/bifrostlab/llm-assistant/devcontainer:latest",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Python 3.12",
+  "image": "ghcr.io/bifrostlab/llm-assistant:latest",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.analysis.typeCheckingMode": "basic",
+        "python.analysis.autoImportCompletions": true
+      },
+      "extensions": [
+        "GitHub.vscode-github-actions",
+        "GitHub.copilot"
+      ]
+    }
+  },
+  "postCreateCommand": "$(pwd)/.devcontainer/post-install.sh"
+}

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+poetry install
+poetry shell

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -3,7 +3,7 @@ name: Build and publish devcontainer
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - .devcontainer/Dockerfile
 

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,22 +1,26 @@
 name: Build and publish devcontainer
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
     paths:
       - .devcontainer/Dockerfile
-    types:
-      - closed
 
 jobs:
   build_dev_container:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-    permissions:
-      packages: write
-      contents: read
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64, arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
@@ -31,6 +35,7 @@ jobs:
           context: .devcontainer
           file: .devcontainer/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/devcontainer:latest
             ghcr.io/${{ github.repository }}/devcontainer:3.12

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,0 +1,37 @@
+name: Build and publish devcontainer
+
+on:
+  pull_request:
+    paths:
+      - .devcontainer/Dockerfile
+    types:
+      - closed
+
+jobs:
+  build_dev_container:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/devcontainer:latest
+            ghcr.io/${{ github.repository }}/devcontainer:3.12
+            ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to LLM-Assistant
+
+Thank you for considering contributing to the LLM-Assistant project! We appreciate your interest and support. This guide will provide you with the necessary information to get started.
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Getting Started](#getting-started)
+- [Development Environment](#development-environment)
+
+## Introduction
+
+LLM-Assistant is a VAIT incubation project that aims to provide a Large Language Model (LLM) assistant for our Discord channel. The project is open-source and welcomes contributions from the community. If you are interested in contributing to LLM-Assistant, please read the following guidelines to get started.
+
+## Getting Started
+
+To get started with contributing to LLM-Assistant, please follow these steps:
+
+1. Fork the repository on GitHub.
+2. Clone your forked repository to your local machine.
+3. Create a new branch for your changes.
+4. Make your desired changes to the codebase.
+5. Test your changes thoroughly.
+6. Commit your changes with a descriptive commit message.
+7. Push your changes to your forked repository.
+8. Submit a pull request to the main repository.
+
+## Development Environment
+
+LLM-Assistant uses a [devcontainer](https://containers.dev/) to provide a consistent development environment. To set up the devcontainer, follow these steps:
+
+1. [Install Docker](https://docs.docker.com/engine/install/) on your machine if you haven't already.
+2. Install the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in Visual Studio Code.
+3. Open the project folder in [Visual Studio Code](https://code.visualstudio.com/Download).
+4. Click on the green/blue icon in the bottom-left corner of the window and select "Reopen in Container".
+5. Visual Studio Code will automatically build the devcontainer and open a new window with the development environment.


### PR DESCRIPTION
This PR add a Devcontainer environment for LLM-Assistant project. The base image used is mcr.microsoft.com/devcontainers/python:3.12.

This image is then rebuilt to add bash-completion and pre-install poetry as a dependency.

The accompanied CI job only runs when there are changes made to the .devcontainer dockerfile. Whilst devcontainer has the option of building the docker image on the host, preparing the image ahead of time allows us to cache and pin the version of poetry we are running.

The post-installation script will make sure the right virtualenv is selected when the container start. The provided devcontainer image has 2 platforms: linux/amd64 (Unix, Windows) and linux/arm64 (OSX)