### PR TITLE
chore(devcontainer): add mypy extension into devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
         "GitHub.copilot",
         "charliermarsh.ruff",
         "elagil.pre-commit-helper",
-        "EditorConfig.EditorConfig"
+        "EditorConfig.EditorConfig",
+        "ms-python.mypy-type-checker"
       ]
     }
   },


### PR DESCRIPTION
This is an issue arised when I'm reviewing #42 . Apparently, by default the Python extension is VSCode runs on Pylance, which by itself runs on Pyright, and by default does not honor all Mypy rules and plugins and starts giving out false positives. This is a documented issue. See https://github.com/microsoft/pylance-release/issues/290

This PR will install mypy into the devcontainer's vscode, which will honor mypy rules.

See ma, no type errors!
![image](https://github.com/bifrostlab/llm-assistant/assets/4188758/169f4bf9-02af-4ef1-87c4-3018364dbc6c)
