### PR TITLE
ci: Remove poetry lock from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,3 @@ repos:
   rev: 1.7.1
   hooks:
     - id: poetry-check
-    - id: poetry-lock


### PR DESCRIPTION
Remove the poetry lock check from pre-commit hook. This is to make sure we don't bump every minor version of the dependencies.

The check is added earlier during the development cycle because we are not using devcontainer and running off Python 3.10.