### PR TITLE
build: Add build and publish pipeline by Docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build the container image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - src/**
+      - poetry.lock
+      - pyproject.toml
+
+jobs:
+  build:
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64, arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}/llm-assistant:latest
+            ghcr.io/${{ github.repository }}/llm-assistant:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine as build
+FROM python:3.12 as build
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY src ./src
 RUN poetry install --compile --without dev
 RUN poetry build && poetry run pip install /app/dist/*.whl
 
-FROM python:3.12-alpine as runtime
+FROM python:3.12-slim as runtime
 
 COPY --from=build /app/.venv /app/.venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12 as build
+FROM python:3.12-alpine as build
 
 WORKDIR /app
 
@@ -10,13 +10,13 @@ ENV POETRY_NO_INTERACTION=1 \
 
 RUN pip install poetry==${POETRY_VERSION}
 
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml poetry.lock README.md ./
 COPY src ./src
 
 RUN poetry install --compile --without dev
 RUN poetry build && poetry run pip install /app/dist/*.whl
 
-FROM python:3.12-slim as runtime
+FROM python:3.12-alpine as runtime
 
 COPY --from=build /app/.venv /app/.venv
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a multifunctional assistant bot for Discord. It is designed by V
 ### Setting up the bot in Discord
 
 - [Create a bot in discord](https://interactions-py.github.io/interactions.py/Guides/02%20Creating%20Your%20Bot/).
-- Add that bot to your server server.
+- Add that bot to your server.
   - When making the invite through OAuth2 URL Generator, make sure to enable `bot` and `applications.commands` options.
   - Follow the [Invite your bot](https://interactions-py.github.io/interactions.py/Guides/02%20Creating%20Your%20Bot/) section for reference.
 - Copy out `.env.example` into `.env`, and fill in the `DISCORD_BOT_TOKEN` and `DISCORD_GUILD_ID`.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,14 @@
 # Multifunctional LLM Assistant for Discord
 
-## Dependencies Installation
+This project is a multifunctional assistant bot for Discord. It is designed by VAIT to help our members with various tasks, such as testing LLM models and quickly review our members resume.
 
-We will use [Poetry](https://python-poetry.org/docs/) in this project. Please visit the link to install poetry on your local machine.
+## How to Run this Bot
 
-After successfully installing Poetry, use the following command to install the project dependencies:
-
-```shell
-poetry install
-```
-
-This command will create a Python virtual environment and install all the required dependencies into that environment.
-
-To activate the Python environment, run:
-
-```shell
-poetry shell
-```
-
-When you’re done working in the virtual environment, simply type:
-
-```shell
-exit
-```
-
----
-
-## Discord Bot Development
-
-### Getting started
+### Setting up the bot in Discord
 
 - [Create a bot in discord](https://interactions-py.github.io/interactions.py/Guides/02%20Creating%20Your%20Bot/).
-- Add that bot to a test server.
+- Add that bot to your server server.
   - When making the invite through OAuth2 URL Generator, make sure to enable `bot` and `applications.commands` options.
   - Follow the [Invite your bot](https://interactions-py.github.io/interactions.py/Guides/02%20Creating%20Your%20Bot/) section for reference.
 - Copy out `.env.example` into `.env`, and fill in the `DISCORD_BOT_TOKEN` and `DISCORD_GUILD_ID`.
-- Now, run the bot code locally and test the bot on your server.
+- Now, run the bot code locally; alternatively, you can deploy the bot in a docker-compose environment. See the sister repository [deploy-llm-bot](https://github.com/bifrostlab/deploy-llm-bot) for more information.

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -1,7 +1,7 @@
 import interactions
 import re
-import llm
-from settings import Settings
+from discord_bot import llm
+from discord_bot.settings import Settings
 
 
 MODEL_CHOICES = ["gpt-3.5-turbo", "gpt-4", "phi"]


### PR DESCRIPTION
Add github workflow to build and publish Docker image.

Switch to using python-3.12-alpine to reduce the image size and vulnerability factors.

Poetry install now requires a README.md for package, add that into the Docker build pipeline.

Use explicit module naming to make sure the app can run properly in production.