### PR TITLE
hotfix: Add missing runs-on property in GH workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,11 @@ on:
       - src/**
       - poetry.lock
       - pyproject.toml
+      - .github/workflows/build.yml
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Add missing runs-on property and retrigger the run pipeline.