### PR TITLE
build: Use dotenv and remove pydantic-settings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -828,25 +828,6 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
-name = "pydantic-settings"
-version = "2.2.1"
-description = "Settings management using Pydantic"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pydantic_settings-2.2.1-py3-none-any.whl", hash = "sha256:0235391d26db4d2190cb9b31051c4b46882d28a51533f97440867f012d4da091"},
-    {file = "pydantic_settings-2.2.1.tar.gz", hash = "sha256:00b9f6a5e95553590434c0fa01ead0b216c3e10bc54ae02e37f359948643c5ed"},
-]
-
-[package.dependencies]
-pydantic = ">=2.3.0"
-python-dotenv = ">=0.21.0"
-
-[package.extras]
-toml = ["tomli (>=2.0.1)"]
-yaml = ["pyyaml (>=6.0.1)"]
-
-[[package]]
 name = "pytest"
 version = "8.1.1"
 description = "pytest: simple powerful testing with Python"
@@ -1179,4 +1160,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "091e7873945ab6427cb891116fca0d82159701678b1d6200de1f900806ded3ef"
+content-hash = "31b5c5cf3abf68bde5b6de3eb8f45d4308ff6f394a863313dfc89fc45f939267"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ python = "^3.12"
 openai = "^1.11.1"
 python-dotenv = "^1.0.1"
 discord-py-interactions = "5.11.0"
-pydantic-settings = "^2.2.1"
 pydantic = "^2.6.3"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -1,13 +1,16 @@
+import dotenv
 import interactions
+import os
 import re
-from discord_bot import llm
-from discord_bot.settings import Settings
 
+from discord_bot import llm
+
+dotenv.load_dotenv()
 
 MODEL_CHOICES = ["gpt-3.5-turbo", "gpt-4", "phi"]
-DEFAULT_MODEL = MODEL_CHOICES[2]
-DISCORD_BOT_TOKEN = Settings().DISCORD_BOT_TOKEN
-AI_SERVER_URL = Settings().AI_SERVER_URL
+DEFAULT_MODEL = os.environ.get("LLM_DEFAULT_MODEL", "phi")
+DISCORD_BOT_TOKEN = os.environ["DISCORD_BOT_TOKEN"]
+AI_SERVER_URL = os.environ["AI_SERVER_URL"]
 
 bot = interactions.Client(intents=interactions.Intents.DEFAULT)
 

--- a/src/discord_bot/settings.py
+++ b/src/discord_bot/settings.py
@@ -1,8 +1,0 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-
-class Settings(BaseSettings):
-  model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
-
-  DISCORD_BOT_TOKEN: str
-  AI_SERVER_URL: str = "http://localhost:8000"


### PR DESCRIPTION
This PR removes the use of `pydantic-settings` and use `dotenv` to load environments variables.

`settings.py` assumes a `.env` is always available and required in the application for it to deploy. While this design works in dev, it will broke the Docker image. `.env` is meant to be ephemeral. In production, the environment is set directly during deploy.

As such, `pydantic-settings` can be removed and the `dotenv` is better suited to take in the environment variable.

This PR also ensure the model choices are now not-hardcoded and can be overrided by the `LLM_DEFAULT_MODEL` variable. By default, this `DEFAULT_MODEL` is set to `phi` to maintain backward compatibility.