### PR TITLE
test: remove unrelated autocomplete test

### DIFF
--- a/src/autocompletes/select-model/autocomplete.test.ts
+++ b/src/autocompletes/select-model/autocomplete.test.ts
@@ -10,16 +10,6 @@ describe('autocomplete', () => {
     mockReset(mockAutocompleteInteraction);
   });
 
-  it("Should return nothing if the short term isn't long enough", async () => {
-    mockAutocompleteInteraction.options.getString.mockReturnValueOnce('solve');
-    const respondInput = captor<Parameters<AutocompleteInteraction['respond']>['0']>();
-
-    await selectModelAutocomplete(mockAutocompleteInteraction);
-
-    expect(mockAutocompleteInteraction.respond).toBeCalledWith(respondInput);
-    expect(respondInput.value.length).toEqual(0);
-  });
-
   it('Should return nothing if no options are found', async () => {
     mockAutocompleteInteraction.options.getString.mockReturnValueOnce('some random search that not existed');
     const respondInput = captor<Parameters<AutocompleteInteraction['respond']>['0']>();


### PR DESCRIPTION
This parameter is controlled by the Discord UI. In no way it will reach our internal code, so testing it is pointless
